### PR TITLE
Add each_page for iterating through each page

### DIFF
--- a/lib/her/kaminari.rb
+++ b/lib/her/kaminari.rb
@@ -11,3 +11,4 @@ end
 require 'her/kaminari/collection'
 require 'her/kaminari/header_parser'
 require 'her/kaminari/version'
+require 'her/kaminari/relation_extension'

--- a/lib/her/kaminari/collection.rb
+++ b/lib/her/kaminari/collection.rb
@@ -13,6 +13,7 @@ module Her
           scope :per,  ->(per_page) { where(per_page:  per_page || 50) }
         end
         base.extend(ClassMethods)
+        base::Relation.include(Her::Kaminari::RelationExtension)
       end
 
       module ClassMethods

--- a/lib/her/kaminari/relation_extension.rb
+++ b/lib/her/kaminari/relation_extension.rb
@@ -1,0 +1,38 @@
+# -*- encoding : utf-8 -*-
+# lib/her/kaminari/relation_extension.rb
+module Her
+  module Kaminari
+    module RelationExtension
+      def self.included(base)
+        base.class_eval do
+          # Iterates through each page.
+          #
+          # Useful for stitching together an array of all records, across every
+          # page. For example:
+          #
+          #   users = User.all.each_page.flat_map(&:to_a)
+          #
+          # If there are 3 total pages, it would result in these HTTP requests:
+          #
+          #   GET /v1/users
+          #   GET /v1/users?page=2
+          #   GET /v1/users?page=3
+          #
+          # ...and this array of users (25 records per page):
+          #
+          #   users.count
+          #   # => 75
+          #
+          # With the exception of the first one, pages are lazily fetched.
+          def each_page
+            return to_enum(:each_page) unless block_given?
+
+            (current_page..total_pages).each do |number|
+              yield (number == current_page) ? self : page(number)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/lib/her/kaminari/relation_extension_test.rb
+++ b/test/lib/her/kaminari/relation_extension_test.rb
@@ -1,0 +1,24 @@
+# -*- encoding : utf-8 -*-
+# test/lib/her/kaminari/relation_extension_test.rb
+require 'test_helper'
+
+describe Her::Kaminari::RelationExtension do
+  before do
+    @model = Class.new do
+      include Her::Model
+      include Her::Kaminari::Collection
+
+      root_element :champion
+    end
+  end
+
+  describe '.each_page' do
+    before { @subject = @model.all.each_page }
+
+    it 'yields each page' do
+      @subject.count.must_equal 2
+      @subject.map(&:current_page).must_equal [1, 2]
+      @subject.map(&:count).must_equal [5, 4]
+    end
+  end
+end


### PR DESCRIPTION
Useful for stitching together an array of all records, across every page. For example:

``` ruby
users = User.all.each_page.flat_map(&:to_a)
```

If there are 3 total pages, it would result in these HTTP requests:

```
GET /v1/users
GET /v1/users?page=2
GET /v1/users?page=3
```

…and this array of users (25 records per page):

``` ruby
users.count
# => 75
```

With the exception of the first one, pages are lazily fetched.
