### PR TITLE
fix private method include

### DIFF
--- a/lib/her/kaminari/collection.rb
+++ b/lib/her/kaminari/collection.rb
@@ -13,7 +13,7 @@ module Her
           scope :per,  ->(per_page) { where(per_page:  per_page || 50) }
         end
         base.extend(ClassMethods)
-        base::Relation.include(Her::Kaminari::RelationExtension)
+        base::Relation.send(:include, Her::Kaminari::RelationExtension)
       end
 
       module ClassMethods


### PR DESCRIPTION
 Ruby 2.0 in production raise error:
private method `include' called for Her::Model::Relation:Class

this commit fix this error
